### PR TITLE
Add conditional dependency for dynare-preprocessor-pylib

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -29,7 +29,8 @@ requirements:
     - typing_extensions
     - plotly
     - scipy
-    - dynare-preprocessor-pylib
+    - if: unix
+      then: dynare-preprocessor-pylib
 
 tests:
   - python:


### PR DESCRIPTION
Conditionally include dynare-preprocessor-pylib for Unix systems.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
